### PR TITLE
target: Fix renaming.

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -19,6 +19,15 @@ func Sanitize(s string) string {
 	return strings.ToLower(reg.ReplaceAllString(s, ""))
 }
 
+// SanitizeRoomid returns a new string with non-alphanumeric characters removed,
+// excepting hyphens. This is used for returning the proper roomids used on PS! -
+// groupchats are formatted as groupchat-CREATOR-NAME, and without these hyphens,
+// we are given an incorrect identifier.
+func SanitizeRoomid(s string) string {
+	reg := regexp.MustCompile("[^A-Za-z0-9-]")
+	return strings.ToLower(reg.ReplaceAllString(s, ""))
+}
+
 // Public API for access to the LoggerList loggers.
 
 // CheckErr checks if an error is nil, and if it is not, logs the error to

--- a/target.go
+++ b/target.go
@@ -1,4 +1,4 @@
-package sdbot
+﻿package sdbot
 
 import (
 	"fmt"
@@ -142,7 +142,7 @@ func FindUserEnsured(name string, b *Bot) *User {
 
 // FindRoomEnsured finds a room if it exists, creates the room if it doesn't.
 func FindRoomEnsured(name string, b *Bot) *Room {
-	sn := Sanitize(name)
+	sn := SanitizeRoomid(name)
 
 	var updateRooms = func() interface{} {
 		if b.RoomList[sn] != nil {


### PR DESCRIPTION
`Sanitize` was used within `sdbot.FindRoomEnsured` in order to create a unique identifier for rooms while the actual room name was used in `r.Name`. This was never a problem until my bot crashed upon being promoted within my test groupchat.

As it turns out, within `sdbot.Rename`, `r.Name` stored the hyphens within the groupchat while `b.RoomList` stored the name without the hyphens; the bot was trying to locate a room that supposedly didn't exist.

Since hyphens are necessary identifiers within groupchats, I've added a second helper function, `SanitizeRoomid`, that removes all non-alphanumeric characters *except* hyphens. This fixed the issue upon local testing.